### PR TITLE
pam: Use Box::from_raw

### DIFF
--- a/pam/src/lib.rs
+++ b/pam/src/lib.rs
@@ -245,7 +245,7 @@ pub unsafe extern "C" fn pam_sm_open_session(
         return PAM_SUCCESS;
     }
 
-    let password = unsafe { &*(password_ptr as *const Zeroizing<Vec<u8>>) };
+    let password = unsafe { Box::from_raw(password_ptr.cast::<Zeroizing<Vec<u8>>>().cast_mut()) };
     tracing::debug!(
         "Retrieved stashed password of length {} bytes",
         password.len()


### PR DESCRIPTION
The password comes from a Box::into_raw so we reconstruct the Box to avoid it from leaking. See
https://doc.rust-lang.org/std/boxed/struct.Box.html#method.into_raw.